### PR TITLE
Updated authorization header RegEx to correctly match most possible MongoDB URI combinations

### DIFF
--- a/src/lib/mongo.ts
+++ b/src/lib/mongo.ts
@@ -1,8 +1,22 @@
 import { MongoClient } from "mongodb";
+import { z } from "zod";
 
 async function connectToClient(connectionUri: string) {
 	const client = new MongoClient(connectionUri);
 	return client;
 }
 
-export default connectToClient;
+// Schema for the request headers
+const headerSchema = z.object({
+	authorization: z
+		.string()
+		.startsWith("mongodb")
+		.regex(
+			new RegExp(
+				"^(mongodb(?:\\+srv)?://)(?:([^:@]+):([^@]*)@)?([^/?#,]+)(?::(\d+))?(?:/([^?]*))?(?:\\?([^#]*))?$",
+				"gm"
+			)
+		),
+});
+
+export { connectToClient, headerSchema };

--- a/src/routes/action/aggregate.ts
+++ b/src/routes/action/aggregate.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -10,19 +10,6 @@ const bodySchema = z.object({
 	database: z.string(),
 	collection: z.string(),
 	pipeline: z.array(z.record(z.any())),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/deleteMany.ts
+++ b/src/routes/action/deleteMany.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -10,19 +10,6 @@ const bodySchema = z.object({
 	database: z.string(),
 	collection: z.string(),
 	filter: z.record(z.any()),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/deleteOne.ts
+++ b/src/routes/action/deleteOne.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -10,19 +10,6 @@ const bodySchema = z.object({
 	database: z.string(),
 	collection: z.string(),
 	filter: z.record(z.any()),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/find.ts
+++ b/src/routes/action/find.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -14,19 +14,6 @@ const bodySchema = z.object({
 	sort: z.record(z.number()).optional(),
 	limit: z.number().optional(),
 	skip: z.number().optional(),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/findOne.ts
+++ b/src/routes/action/findOne.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -14,19 +14,6 @@ const bodySchema = z.object({
 	sort: z.record(z.number()).optional(),
 	limit: z.number().optional(),
 	skip: z.number().optional(),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/insertMany.ts
+++ b/src/routes/action/insertMany.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -10,19 +10,6 @@ const bodySchema = z.object({
 	database: z.string(),
 	collection: z.string(),
 	documents: z.array(z.record(z.any())),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/insertOne.ts
+++ b/src/routes/action/insertOne.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -10,19 +10,6 @@ const bodySchema = z.object({
 	database: z.string(),
 	collection: z.string(),
 	document: z.record(z.any()),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/updateMany.ts
+++ b/src/routes/action/updateMany.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -12,19 +12,6 @@ const bodySchema = z.object({
 	filter: z.record(z.any()),
 	update: z.record(z.any()),
 	upsert: z.boolean().optional(),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(

--- a/src/routes/action/updateOne.ts
+++ b/src/routes/action/updateOne.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import connectToClient from "../../lib/mongo.js";
+import { connectToClient, headerSchema } from "../../lib/mongo.js";
 import { z } from "zod";
 
 const app = new Hono();
@@ -12,19 +12,6 @@ const bodySchema = z.object({
 	filter: z.record(z.any()),
 	update: z.record(z.any()),
 	upsert: z.boolean().optional(),
-});
-
-// Schema for the request headers
-const headerSchema = z.object({
-	authorization: z
-		.string()
-		.startsWith("mongodb")
-		.regex(
-			new RegExp(
-				"^(mongodb(?:\\+srv)?(\\:)(?:\\/{2}){1})(?:\\w+\\:\\w+\\@)?(\\w+?(?:\\.\\w+?)*)(\\:)(\\d+(?:\\/){0,1})(?:\\/\\w+?)?(?:\\?\\w+?\\=\\w+?(?:\\&\\w+?\\=\\w+?)*)?$",
-				"gm"
-			)
-		),
 });
 
 app.post(


### PR DESCRIPTION
This pull request resolves issue #1 posted by me.
In addition to the RegEx fix, I moved the headerSchema to be a reusable `mongo.ts` export.